### PR TITLE
DAP requires variable name to be a string

### DIFF
--- a/lua/osv/init.lua
+++ b/lua/osv/init.lua
@@ -383,7 +383,7 @@ function M.wait_attach()
 
           else
             local v = {}
-            v.name = ln
+            v.name = tostring(ln)
             v.variablesReference = 0
             if type(lv) == "table" then
               vars_ref[vars_id] = lv
@@ -408,7 +408,7 @@ function M.wait_attach()
 
           else
             local v = {}
-            v.name = ln
+            v.name = tostring(ln)
             v.variablesReference = 0
             if type(lv) == "table" then
               vars_ref[vars_id] = lv
@@ -425,7 +425,7 @@ function M.wait_attach()
       elseif type(ref) == "table" then
         for ln, lv in pairs(ref) do
             local v = {}
-            v.name = ln
+            v.name = tostring(ln)
             v.variablesReference = 0
             if type(lv) == "table" then
               vars_ref[vars_id] = lv

--- a/src/handlers/variables.lua.t
+++ b/src/handlers/variables.lua.t
@@ -41,7 +41,7 @@ end
 if vim.startswith(ln, "(") then
 
 @fill_variable_struct+=
-v.name = ln
+v.name = tostring(ln)
 v.variablesReference = 0
 if type(lv) == "table" then
   @make_variable_reference_for_table


### PR DESCRIPTION
I was getting `E5108: Error executing lua .../nvim/site/pack/packer/start/nvim-dap/lua/dap/entity.lua:36: attempt to get length of field 'name' (a
 number value)` when debug with OSV
