### PR TITLE
readme(example) Don't make the user manually launching osv

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ dap.configurations.lua = {
     type = 'nlua', 
     request = 'attach',
     name = "Attach to running Neovim instance",
+    program = function() require"osv".launch({port = 8086}) end,
   }
 }
 


### PR DESCRIPTION
With this new line the example config works right off the bait just copy pasting it.