### PR TITLE
Fix 'harmless' typo on variable name

### DIFF
--- a/lua/osv/init.lua
+++ b/lua/osv/init.lua
@@ -190,7 +190,7 @@ function M.launch(opts)
   	return
   end
 
-  if not hook_addres then
+  if not hook_address then
     hook_address = vim.fn.serverstart()
   end
 

--- a/src/launch.lua.t
+++ b/src/launch.lua.t
@@ -41,7 +41,7 @@ end
 local hook_address
 
 @set_hook_instance_address+=
-if not hook_addres then
+if not hook_address then
   hook_address = vim.fn.serverstart()
 end
 


### PR DESCRIPTION
That only caused an issue for me because my lua setup uses barewords :sweat_smile: 