### PR TITLE
feat: implement DAP `OutputEvent`

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup neovim
         uses: rhysd/action-setup-vim@v1
         with:

--- a/.github/workflows/test-osv.yml
+++ b/.github/workflows/test-osv.yml
@@ -8,10 +8,10 @@ jobs:
         neovim_version: ['nightly', 'stable', 'v0.9.0', 'v0.10.0']
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: date +%F > todays-date
       - name: Restore cache for today's nightly
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _neovim
           key: ${{ runner.os }}-x64-${{ hashFiles('todays-date') }}

--- a/README.md
+++ b/README.md
@@ -87,10 +87,14 @@ Set `nest_if_no_args` to true. See [this issue](https://github.com/willothy/flat
 
 Under special circumstances, the headless instance can fail. See [this issue](https://github.com/jbyuki/one-small-step-for-vimkind/issues/45#issuecomment-2125749906) for more details.
 
+### Neovim messages and output
+
+Currently, `:redir` is used in the debuggee to capture and report debuggee output. This was chosen because it is rarely used in neovim and has relatively few side-effects. However, vim/nvim only allows 1 redirection to be active at a time. If your program relies on this command working correctly, you may need to set `output` to `false`, otherwise your redirections will be overridden.
+
 ### Debugging plugins
 
 Breakpoints are path-sensitive so they should always be set in the executed file
-even though they might be multiple copies on the system.
+even though there might be multiple copies on the system.
 
 This is the case for [packer.nvim](https://github.com/wbthomason/packer.nvim) when developing
 local plugins. packer.nvim will create a symlink to the plugins files in the `nvim-data` directory (
@@ -147,7 +151,7 @@ Events:
 * [x] stopped
 * [x] terminated
 * [x] exited
-* [ ] output
+* [x] output (but see [the caveat](#neovim-messages-and-output))
 
 Capabilities:
 

--- a/doc/osv.txt
+++ b/doc/osv.txt
@@ -1,6 +1,6 @@
 one-small-step-for-vimkind             *one-small-step-for-vimkind* *osv*
 
-|one-small-step-for-vimkind| (osv) is an adapter for Lua running inside Neovim. 
+|one-small-step-for-vimkind| (osv) is an adapter for Lua running inside Neovim.
 It will allow you to:
 
   * Debug Lua scripts
@@ -21,57 +21,57 @@ is the one recommended.
 =========================================================================
 nvim-dap                                                        *osv-dap*
 
-Please refer |dap-adapter| and |dap-configuration| to know about about
-nvim-dap configurations.
+Please refer to |dap-adapter| and |dap-configuration| to learn about nvim-dap
+configurations.
 
 The following configuration will allow you to attach a nvim-dap
 client to |osv|.
->
-  local dap = require"dap"
-  dap.configurations.lua = { 
-    { 
-      type = 'nlua', 
-      request = 'attach',
-      name = "Attach to running Neovim instance",
+>lua
+    local dap = require"dap"
+    dap.configurations.lua = {
+      {
+        type = 'nlua',
+        request = 'attach',
+        name = "Attach to running Neovim instance",
+      }
     }
-  }
 
-  dap.adapters.nlua = function(callback, config)
-    callback({ type = 'server', host = config.host or "127.0.0.1", port = config.port or 8086 })
-  end
-
+    dap.adapters.nlua = function(callback, config)
+      callback({ type = 'server', host = config.host or "127.0.0.1", port = config.port or 8086 })
+    end
 <
+
 QUICKSTART
 
-The following steps will guide you through the process to start
-a debugging session using nvim-dap.
+The following steps will guide you through the process of starting a debug
+session using nvim-dap.
 
-Let's say you have a lua script `myscript.lua` in your home directory.
-It has the following content: >
+Let's say you have a lua script `myscript.lua` in your home directory that has
+the following content: >lua
 
-  print("start")
-  for i=1,10 do
-    print(i)
-  end
-  print("end")
+    print("start")
+    for i = 1, 10 do
+      print(i)
+    end
+    print("end")
 <
 1. Open a Neovim instance (instance A)
-2. Launch the DAP server with (A) >
- :lua require"osv".launch({port=8086})
+2. Launch the DAP server with (A) >vim
+    :lua require"osv".launch({port=8086})
 3. Open another Neovim instance (instance B)
 4. Open `myscript.lua` (B)
-5. Place a breakpoint on line 2 using (B) >
-  :lua require"dap".toggle_breakpoint()
-6. Connect the DAP client using (B) >
-  :lua require"dap".continue()
-7. Run `myscript.lua` in the other instance (A) >
-  :luafile myscript.lua
+5. Place a breakpoint on line 2 using (B) >vim
+    :lua require"dap".toggle_breakpoint()
+6. Connect the DAP client using (B) >vim
+    :lua require"dap".continue()
+7. Run `myscript.lua` in the other instance (A) >vim
+    :luafile myscript.lua
 8. The breakpoint should hit and freeze the instance (B)
 
 =========================================================================
 vimspector configuration                           *lua-debug-vimspector*
 
->
+>json
   {
     "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json#",
     "adapters": {
@@ -95,72 +95,67 @@ vimspector configuration                           *lua-debug-vimspector*
 =========================================================================
 Launch server                                               *osv-server*
 
-To start a debugging session, you will first need to launch the server. 
+To start a debugging session, you will first need to launch the server.
 
 launch({opts})                                           *osv.launch()*
+    This command will launch the DAP server awaiting any connections. Upon
+    execution, a prompt message will display the port it's running on.
 
-This command will launch the DAP server awaiting any connections. On
-execution, a prompt message will display the port it's running on.
+    Parameters: ~
+      • {opts}  Optional parameters.
+                • `host`         Defaults to "127.0.0.1".
+                • `port`         Specify a port number. If nil, the server will choose it.
+                • `config_file`  Specify a configuration file used when spawning nvim.
+                • `log`          (bool) Enable logging.
+                • `recursive`    (bool) If true, will not check for recursive launch
+                               calls (default is false).
+                • `blocking`     (bool) If true, will freeze the instance until a
+                               client is connected (default is false)
+                • `output`       (bool) Capture and report nvim output/messages in
+                               the debuggee (default is true). Note: This is
+                               implemented via |:redir| internally. See
+                               |:redir| for caveats.
 
-    Parameters:
-        {opts} Optional parameters.
-               • `host`: defaults to "127.0.0.1"
-               • `port`: Specify a port number or if nil, lets the server
-		       choose it.
-               • `config_file`: Specify a configuration file used when
-                              spawning nvim
-               • `log`: boolean to enable logging
-               • `recursive`: (bool) if true, will not check for recursive launch
-               calls (default is false)
-               • `blocking`: (bool) if true, will freeze the instance until a
-               client is connected (default is false)
+    Return: ~
+        A server info object which contains `{ host = host, port = port }`, or
+        `nil` on failure
 
-    Return:
-        An server info object which contains 
-          {host = {host}, port = {port}} 
-        or nil on failure
-
-The |osv.launch()| function will actually not 
-run the server in the running process but spawn a child process. 
-This ensures that DAP requests are still processed even in a 
-frozen state.
+The |osv.launch()| function will run the debug adapter server in a child
+process. This ensures that DAP requests are still processed even in a frozen
+state.
 
 run_this({opts})                                        *osv.run_this()*
+    This command will automatically start the DAP server and connect nvim-dap
+    to it. You still need to set the `dap.adapters.nlua` as explained in the
+    configuration section.
 
-    Parameters:
-        {opts} Optional parameters.
-               • `config_file`: (string) See |osv.launch()|
-               • `log`: (bool) boolean to enable logging
+    Parameters: ~
+      • {opts} Optional parameters.
+               • `config_file`  (string) See |osv.launch()|.
+               • `log`          (bool) Enable logging.
+               • `output`       (bool) See |osv.launch()|.
 
-
-This command will automatically start the DAP server and connect
-nvim-dap to it. You still need to set the `dap.adapters.nlua` as 
-explained in the configuration section.
 
 stop()                                                     *osv.stop()*
-
-This command will stop the running dap server. Following the DAP
-standard, an "exited" event + an "terminated" will be sent to the client
-so that it knows the server has exited.
+    This command will stop the running dap server. Following the DAP standard,
+    an "exited" event + a "terminated" event will be sent to the client so
+    that it knows the server has exited.
 
 start_trace()						*osv.start_trace()*
-
-Start a tracing session which records every line that gets executed
-in the current Neovim instance. Stop it with |osv.stop_trace()|.
+    Start a tracing session which records every line that gets executed in the
+    current Neovim instance. Stop it with |osv.stop_trace()|.
 
 stop_trace()						*osv.stop_trace()*
+    Stop the tracing session.
 
-Stop the tracing session.
-
-    Return:~
+    Return: ~
 	A dictionary with the source path as key and a table
 	for each key with the executed line numbers.
 
 is_running()						*osv.is_running()*
+    Checks whether |osv| is currently running.
 
-Checks whether |osv| is currently running.
-
-    Return:~
+    Return: ~
 	True if osv is running.
 
 
@@ -173,24 +168,26 @@ bevahiour is executed, otherwise the callback will be called instead. Only one
 callback can be assigned to an action.
 
 For example:
->
-  require"osv".on["action"] = function(...)
-  end
-<
+>lua
+    require"osv".on["action"] = function(...)
+    end
+
 The `start_server` event is called when osv starts the headless instance for
 the DAP server. The default behaviour is:
->
-  require"osv".on["start_server"] = function(args, env)
-    return vim.fn.jobstart(args, {rpc = true, env = env})
-  end
+>lua
+    require"osv".on["start_server"] = function(args, env)
+      return vim.fn.jobstart(args, {rpc = true, env = env})
+    end
+<
 
 =========================================================================
 osv logging                                                 *osv-logging*
 
 Logging can be enabled by passing the corresponding parameter in
 |osv.launch|. The log will be written in:
->
-  vim.fn.stdpath('data') .. '/osv.log'
+>lua
+    vim.fn.stdpath('data') .. '/osv.log'
+<
 
 =========================================================================
 init.lua debugging                                        *osv-init-debug*
@@ -199,18 +196,18 @@ To debug the `init.lua` configuration file, you'll need to take a few
 additional steps to start the debugger at launch.
 
 1. Add the following code near the top of your `init.lua`:
->
-  if init_debug then
-    require"osv".launch({port=8086, blocking=true})
-  end
+>lua
+    if init_debug then
+      require"osv".launch({port=8086, blocking=true})
+    end
 <
 When the global variable init_debug is set to true, this will launch a
 debugging server from the `init.lua` file. The blocking flag will pause the
 instance, waiting for a client connection.
 
 2. Launch the debuggee instance with:
->
-  nvim --cmd "lua init_debug=true"
+>sh
+    nvim --cmd "lua init_debug=true"
 
 The instance should freeze immediately.
 
@@ -219,17 +216,18 @@ The instance should freeze immediately.
 Execution should resume until it reaches the breakpoint, allowing you to
 step through the `init.lua` code.
 
+
 =========================================================================
 osv plugins debugging                             *osv-plugins-debugging
 
-Note: These explanations only are valid if you're using packer.nvim for
-other plugin managers such as vim-plug you don't need to take special
-precautions to debug plugins
+Note: These explanations only are valid if you're using packer.nvim. For
+other plugin managers such as vim-plug, you don't need to take any special
+precautions to debug plugins.
 
 As an example, let's say you're developing a plugin which is located
 in a directory on your system. You would install it using:
->
-  use '...path to your plugin.../my-plugin.nvim'
+>lua
+    use '...path to your plugin.../my-plugin.nvim'
 <
 After installing `my-plugin.nvim` using packer.nvim, a symlink will be created
 inside the `nvim-data`  which points to your local plugin directory.
@@ -247,11 +245,13 @@ contain breakpoints match and stop on trigger.
 In consequence, reopen the files through the symlink and place the breakpoints
 there to properly trigger them.
 
+
 =========================================================================
 osv repl                                                      *osv-repl*
 
 The REPL supports evaluation of expression. It will prepend a "return "
 statement which will return the value of the expression to the debugger.
 This means expressions such as assignments will not be valid syntax.
+
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/osv/init.lua
+++ b/lua/osv/init.lua
@@ -34,6 +34,9 @@ local skip_monitor_same_depth = false
 
 local head_start_depth = -1
 
+local redir_nvim_output = true
+local nvim_exec2_opts = {}
+
 local exit_autocmd
 
 local auto_nvim
@@ -98,13 +101,10 @@ function M.launch(opts)
     vim.validate {
       ["opts.host"] = {opts.host, "s", true},
       ["opts.port"] = {opts.port, "n", true},
-    }
-  end
-
-  if opts then
-    vim.validate {
       ["opts.config_file"] = {opts.config_file, "s", true},
+      ["opts.output"] = {opts.output, "b", true},
     }
+    if opts.output ~= nil then redir_nvim_output = opts.output end
   end
 
   if not opts or not opts.recursive then
@@ -956,6 +956,27 @@ function M.attach()
 
     M.server_messages = {}
 
+    if redir_nvim_output and not vim.in_fast_event() then
+      -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+      pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+      local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+      if ok then
+        if type(msgs) ~= 'string' then
+          error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+        elseif #msgs > 0 then
+          local event = make_event 'output'
+          event.body = { category = 'stdout', output = msgs }
+          sendProxyDAP(event)
+        end
+      end
+
+      -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+      -- variable if it doesn't already exist, and clears it. Messages are still
+      -- displayed on-screen in debuggee as usual. This should also work when nvim
+      -- is headless.
+      pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+    end
 
     local depth = -1
     if (event == "call" or event == "return") and monitor_stack and next then
@@ -1250,6 +1271,27 @@ function M.attach()
 
       				  M.server_messages = {}
 
+      				  if redir_nvim_output and not vim.in_fast_event() then
+      				    -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+      				    pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+      				    local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+      				    if ok then
+      				      if type(msgs) ~= 'string' then
+      				        error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+      				      elseif #msgs > 0 then
+      				        local event = make_event 'output'
+      				        event.body = { category = 'stdout', output = msgs }
+      				        sendProxyDAP(event)
+      				      end
+      				    end
+
+      				    -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+      				    -- variable if it doesn't already exist, and clears it. Messages are still
+      				    -- displayed on-screen in debuggee as usual. This should also work when nvim
+      				    -- is headless.
+      				    pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+      				  end
       				  vim.wait(50)
       				end
 
@@ -1323,6 +1365,27 @@ function M.attach()
 
     		  M.server_messages = {}
 
+    		  if redir_nvim_output and not vim.in_fast_event() then
+    		    -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+    		    pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+    		    local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+    		    if ok then
+    		      if type(msgs) ~= 'string' then
+    		        error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+    		      elseif #msgs > 0 then
+    		        local event = make_event 'output'
+    		        event.body = { category = 'stdout', output = msgs }
+    		        sendProxyDAP(event)
+    		      end
+    		    end
+
+    		    -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+    		    -- variable if it doesn't already exist, and clears it. Messages are still
+    		    -- displayed on-screen in debuggee as usual. This should also work when nvim
+    		    -- is headless.
+    		    pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+    		  end
     		  vim.wait(50)
     		end
 
@@ -1361,6 +1424,27 @@ function M.attach()
 
         M.server_messages = {}
 
+        if redir_nvim_output and not vim.in_fast_event() then
+          -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+          pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+          local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+          if ok then
+            if type(msgs) ~= 'string' then
+              error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+            elseif #msgs > 0 then
+              local event = make_event 'output'
+              event.body = { category = 'stdout', output = msgs }
+              sendProxyDAP(event)
+            end
+          end
+
+          -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+          -- variable if it doesn't already exist, and clears it. Messages are still
+          -- displayed on-screen in debuggee as usual. This should also work when nvim
+          -- is headless.
+          pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+        end
         vim.wait(50)
       end
 
@@ -1398,6 +1482,27 @@ function M.attach()
 
         M.server_messages = {}
 
+        if redir_nvim_output and not vim.in_fast_event() then
+          -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+          pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+          local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+          if ok then
+            if type(msgs) ~= 'string' then
+              error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+            elseif #msgs > 0 then
+              local event = make_event 'output'
+              event.body = { category = 'stdout', output = msgs }
+              sendProxyDAP(event)
+            end
+          end
+
+          -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+          -- variable if it doesn't already exist, and clears it. Messages are still
+          -- displayed on-screen in debuggee as usual. This should also work when nvim
+          -- is headless.
+          pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+        end
         vim.wait(50)
       end
 
@@ -1431,6 +1536,27 @@ function M.attach()
 
         M.server_messages = {}
 
+        if redir_nvim_output and not vim.in_fast_event() then
+          -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+          pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+          local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+          if ok then
+            if type(msgs) ~= 'string' then
+              error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+            elseif #msgs > 0 then
+              local event = make_event 'output'
+              event.body = { category = 'stdout', output = msgs }
+              sendProxyDAP(event)
+            end
+          end
+
+          -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+          -- variable if it doesn't already exist, and clears it. Messages are still
+          -- displayed on-screen in debuggee as usual. This should also work when nvim
+          -- is headless.
+          pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+        end
         vim.wait(50)
       end
 
@@ -1681,6 +1807,27 @@ function M.stop()
 		return 
 	end
 
+  if redir_nvim_output and not vim.in_fast_event() then
+    -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+    pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+    local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+    if ok then
+      if type(msgs) ~= 'string' then
+        error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+      elseif #msgs > 0 then
+        local event = make_event 'output'
+        event.body = { category = 'stdout', output = msgs }
+        sendProxyDAP(event)
+      end
+    end
+
+    -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+    -- variable if it doesn't already exist, and clears it. Messages are still
+    -- displayed on-screen in debuggee as usual. This should also work when nvim
+    -- is headless.
+    pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+  end
   sendProxyDAP(make_event("terminated"))
 
   local msg = make_event("exited")

--- a/src/breakpoint/breakpoint_hit.lua.t
+++ b/src/breakpoint/breakpoint_hit.lua.t
@@ -57,6 +57,7 @@ while not running do
   @check_disconnected
   @handle_new_messages
   @clear_messages
+  @handle_nvim_output
   vim.wait(50)
 end
 

--- a/src/handlers/attach.lua.t
+++ b/src/handlers/attach.lua.t
@@ -8,6 +8,7 @@ debug.sethook(function(event, line)
 
   @handle_new_messages
   @clear_messages
+  @handle_nvim_output
 
   local depth = -1
   @speedup_stack_monitor

--- a/src/launch.lua.t
+++ b/src/launch.lua.t
@@ -85,7 +85,10 @@ if opts then
   vim.validate {
     ["opts.host"] = {opts.host, "s", true},
     ["opts.port"] = {opts.port, "n", true},
+    ["opts.config_file"] = {opts.config_file, "s", true},
+    ["opts.output"] = {opts.output, "b", true},
   }
+  if opts.output ~= nil then redir_nvim_output = opts.output end
 end
 
 @detect_if_nvim_is_blocking+=
@@ -94,13 +97,6 @@ if mode.blocking then
 	vim.api.nvim_echo({{"Neovim is waiting for input at startup. Aborting.", "ErrorMsg"}}, true, {})
 	@terminate_adapter_server_process
 	return
-end
-
-@verify_launch_arguments+=
-if opts then
-  vim.validate {
-    ["opts.config_file"] = {opts.config_file, "s", true},
-  }
 end
 
 @fill_env_with_custom+=

--- a/src/output.lua.t
+++ b/src/output.lua.t
@@ -1,0 +1,27 @@
+##lua-debug
+@script_variables+=
+local redir_nvim_output = true
+local nvim_exec2_opts = {}
+
+@handle_nvim_output+=
+if redir_nvim_output and not vim.in_fast_event() then
+  -- Sets `g:_osv_nvim_output` with messages observed since last `:redir`.
+  pcall(vim.api.nvim_exec2, 'silent redir END', nvim_exec2_opts)
+
+  local ok, msgs = pcall(vim.api.nvim_get_var, '_osv_nvim_output')
+  if ok then
+    if type(msgs) ~= 'string' then
+      error('expected g:_osv_nvim_output to be a string but got: ' .. msgs)
+    elseif #msgs > 0 then
+      local event = make_event 'output'
+      event.body = { category = 'stdout', output = msgs }
+      sendProxyDAP(event)
+    end
+  end
+
+  -- Sets `g:_osv_nvim_output` as redir target for nvim messages, creates the
+  -- variable if it doesn't already exist, and clears it. Messages are still
+  -- displayed on-screen in debuggee as usual. This should also work when nvim
+  -- is headless.
+  pcall(vim.api.nvim_exec2, 'silent redir => g:_osv_nvim_output', nvim_exec2_opts)
+end

--- a/src/stop.lua.t
+++ b/src/stop.lua.t
@@ -8,6 +8,7 @@ function M.stop()
 		return 
 	end
 
+  @handle_nvim_output
   @send_terminated_event
   @send_exited_event
   @terminate_adapter_server_process


### PR DESCRIPTION
Implement DAP `OutputEvent` by using the `:redir` vim cmd to capture nvim output.

I believe this is the best solution for handling nvim messages/output (of which lua output constitutes a subset). `:redir` captures all output/messages (incl. errors, etc.), output is still displayed as usual within the debuggee, the redirection cannot be observed or detected (although a single global vim var is required) and there are few side-effects.

The main caveat is that `:redir` overrides any existing "redirection" as only 1 redirection is allowed at a time. This "redirection" is vim-specific and unrelated to fd redirection. I feel that this command is more used in vim than lua or nvim, and when it is used, it is mostly used for debugging purposes.

Another caveat is that vim commands, like vimscript functions, cannot be executed within "lua loop callbacks" or "fast events". So this will not work within those contexts.

Alternatives considered:

- External/custom nvim ui handler. Would be optimal but requires an rpc connection, is more complicated to setup, and probably has too many side-effects (messages will likely be hidden in debuggee, headless nvim instance will appear to have a UI to user code).

- Collecting output with `:messages` command. Basically requires frequently clearing all messages from nvim (e.g. `:messages clear`) which user code might detect or rely on. If you don't clear messages, it is difficult to reliably determine which messages are actually new.

- Redefining printing functions like `print()`, `io.write`, etc. Would work, but probably wouldn't be able to handle error messages, nvim_echo calls, or nvim status messages.

- Capturing or redirecting stdout/stderr of debuggee. This would only work when nvim is headless, and osv would probably need to be the one to launch the debuggee process (as opposed to the user) in order to read from, or redirect, the stdio streams.

Related: #42