### PR TITLE
feat: add on_attach event

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ See [osv.txt](https://github.com/jbyuki/lua-debug.nvim/blob/main/doc/osv.txt) fo
 It is now possible to debug configuration files (ex. `init.lua`).
 See the corresponding section in [osv.txt](https://github.com/jbyuki/lua-debug.nvim/blob/main/doc/osv.txt#L198).
 
+## on_attach() event
+
+The `on_attach` event is called when the adapter is attached to the debuggee.
+It can be used for various purposes, such as resuming the debuggee's execution once a DAP client is attached (great to use alongside automated test plugins like `mini.test`)
+Example:
+
+```lua
+local osv = require"osv"
+local debugger_attached = false
+osv.on_attach = function() debugger_attached = true end
+osv.launch({ port = 8086 })
+-- wait until a debuggee is attached, or 30 seconds
+vim.wait(30000, function() return debugger_attached end, 10)
+```
+
 ## Troubleshoot
 
 ### `flatten.nvim`

--- a/lua/osv/init.lua
+++ b/lua/osv/init.lua
@@ -56,6 +56,8 @@ local log
 
 local M = {}
 M.stop_freeze = false
+---@type function
+M.on_attach = nil
 
 function M.unfreeze()
   if not running then
@@ -936,6 +938,10 @@ function M.attach()
         variables = variables,
       }
     }))
+  end
+
+  if M.on_attach then
+    M.on_attach()
   end
 
   debug.sethook(function(event, line)


### PR DESCRIPTION
fixes #60

## on_attach() event

The `on_attach` event is called when the adapter is attached to the debuggee.
It can be used for various purposes, such as resuming the debuggee's execution once a DAP client is attached (great to use alongside automated test plugins like `mini.test`)
Example:

```lua
local osv = require"osv"
local debugger_attached = false
osv.on_attach = function() debugger_attached = true end
osv.launch({ port = 8086 })
-- wait until a debuggee is attached, or 30 seconds
vim.wait(30000, function() return debugger_attached end, 10)
```
