### PR TITLE
handle invalid level

### DIFF
--- a/lua/osv/init.lua
+++ b/lua/osv/init.lua
@@ -843,6 +843,11 @@ function M.prepare_attach(blocking)
     if type(ref) == "number" then
       local a = 1
       local frame = ref
+      local info = debug.getinfo(frame)
+      if not info then
+        -- Handle invalid level
+        return
+      end
       while true do
         local ln, lv = debug.getlocal(frame, a)
         if not ln then

--- a/lua/osv/init.lua
+++ b/lua/osv/init.lua
@@ -843,14 +843,9 @@ function M.prepare_attach(blocking)
     if type(ref) == "number" then
       local a = 1
       local frame = ref
-      local info = debug.getinfo(frame)
-      if not info then
-        -- Handle invalid level
-        return
-      end
       while true do
-        local ln, lv = debug.getlocal(frame, a)
-        if not ln then
+        local succ, ln, lv = pcall(debug.getlocal, frame, a)
+        if not succ or not ln then
           break
         end
 

--- a/src/handlers/variables.lua.t2
+++ b/src/handlers/variables.lua.t2
@@ -23,8 +23,8 @@ end
 local a = 1
 local frame = ref
 while true do
-  local ln, lv = debug.getlocal(frame, a)
-  if not ln then
+  local succ, ln, lv = pcall(debug.getlocal, frame, a)
+  if not succ or not ln then
     break
   end
 


### PR DESCRIPTION
Problem:

Error occurs in OSV when stepping over:
```
Error executing vim.schedule lua callback:
.../one-small-step-for-vimkind/lua/osv/init.lua:847: 
bad argument #1 to 'getlocal' (level out of range)

Stack traceback:
  [C]: in function 'getlocal'
  .../osv/init.lua:847: in function 'f'
  .../osv/init.lua:930: in function <.../osv/init.lua:921>
  .../lualine/utils.lua:214: in function 'fn'
  vim/_editor.lua:366: in function <vim/_editor.lua:365>
  [C]: in function 'wait'
  .../osv/init.lua:1262: in function '__index'
  .../fittencode/commands.lua:57: in function 'fn'
  .../fittencode/commands.lua:147: in function 'execute'
  .../fittencode/commands.lua:172: in function <.../fittencode/commands.lua:171>
```

Solution:

Fix debug.getlocal() error by validating stack level before calling it in osv/init.lua.
