### PR TITLE
add exception in stack frame analysis

### DIFF
--- a/lua/osv/init.lua
+++ b/lua/osv/init.lua
@@ -615,7 +615,7 @@ function M.prepare_attach(blocking)
       end
 
       local inside_osv = false
-      if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+      if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
         local source = info.source:sub(2)
         -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
         local parent = vim.fs.dirname(source)
@@ -815,7 +815,7 @@ function M.prepare_attach(blocking)
       end
 
       local inside_osv = false
-      if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+      if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
         local source = info.source:sub(2)
         -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
         local parent = vim.fs.dirname(source)
@@ -906,7 +906,7 @@ function M.prepare_attach(blocking)
       end
 
       local inside_osv = false
-      if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+      if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
         local source = info.source:sub(2)
         -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
         local parent = vim.fs.dirname(source)
@@ -1120,7 +1120,7 @@ function M.prepare_attach(blocking)
             end
 
             local inside_osv = false
-            if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+            if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
               local source = info.source:sub(2)
               -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
               local parent = vim.fs.dirname(source)
@@ -1254,7 +1254,7 @@ function M.prepare_attach(blocking)
             end
 
             local inside_osv = false
-            if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+            if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
               local source = info.source:sub(2)
               -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
               local parent = vim.fs.dirname(source)
@@ -1288,7 +1288,7 @@ function M.prepare_attach(blocking)
             end
 
             local inside_osv = false
-            if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+            if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
               local source = info.source:sub(2)
               -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
               local parent = vim.fs.dirname(source)
@@ -1595,7 +1595,7 @@ function M.prepare_attach(blocking)
         	  end
 
         	  local inside_osv = false
-        	  if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+        	  if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
         	    local source = info.source:sub(2)
         	    -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
         	    local parent = vim.fs.dirname(source)
@@ -2077,7 +2077,7 @@ function M.start_trace()
 		  end
 
 		  local inside_osv = false
-		  if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+		  if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
 		    local source = info.source:sub(2)
 		    -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
 		    local parent = vim.fs.dirname(source)

--- a/src/handlers/stack_trace.lua.t2
+++ b/src/handlers/stack_trace.lua.t2
@@ -89,7 +89,7 @@ while true do
 end
 
 ;; check if inside osv
-if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" then
+if info.source:sub(1, 1) == '@' and #info.source > 8 and info.source:sub(#info.source-8+1,#info.source) == "init.lua" and (not info.name or info.name ~= "traceback") then
   local source = info.source:sub(2)
   -- local path = vim.fn.resolve(vim.fn.fnamemodify(source, ":p"))
   local parent = vim.fs.dirname(source)


### PR DESCRIPTION
Issue with `nio` where breakpoint is not hit. `nio` uses `debug.traceback` explicitly and this can cause the shallow stack frame problem.

Attempt to fix #84.